### PR TITLE
Update python_version for 3.13

### DIFF
--- a/ciscoise.json
+++ b/ciscoise.json
@@ -15,7 +15,7 @@
     "logo": "logo_cisco.svg",
     "logo_dark": "logo_cisco_dark.svg",
     "license": "Copyright (c) 2014-2025 Splunk Inc.",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_version": [
         "Cisco ISE version 3.0.0.458, 29 Apr 2024"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)