### PR TITLE
fix: harden Cisco ISE request handling

### DIFF
--- a/ciscoise_connector.py
+++ b/ciscoise_connector.py
@@ -207,12 +207,16 @@ class CiscoISEConnector(BaseConnector):
         verify = config[phantom.APP_JSON_VERIFY]
 
         try:
-            resp = requests.get(  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
-                url, verify=verify, auth=self._auth, stream=True
-            )
+            resp = requests.get(url, verify=verify, auth=self._auth, stream=True, timeout=(10, 60))
         except Exception as e:
             self.debug_print(f"Exception occurred: {e}")
             return action_result.set_status(phantom.APP_ERROR, CISCOISE_ERROR_REST_API, e), ret_data
+
+        try:
+            xml = read_bounded_xml_response(resp)
+        except Exception as e:
+            self.debug_print(f"Exception occurred: {e}")
+            return action_result.set_status(phantom.APP_ERROR, CISCOISE_ERROR_UNABLE_TO_PARSE_REPLY, e), ret_data
 
         if resp.status_code != 200:
             return (
@@ -220,13 +224,12 @@ class CiscoISEConnector(BaseConnector):
                     phantom.APP_ERROR,
                     CISCOISE_REST_API_ERROR_CODE,
                     code=resp.status_code,
-                    message=resp.text,
+                    message=xml[:4096],
                 ),
                 ret_data,
             )
 
         try:
-            xml = read_bounded_xml_response(resp)
             validate_xml_document(xml)
             action_result.add_debug_data(xml)
             response_dict = xmltodict.parse(xml, disable_entities=True)
@@ -778,16 +781,15 @@ class CiscoISEConnector(BaseConnector):
         try:
             rest_endpoint = f"{base_url}{ACTIVE_LIST_REST}"
             self.save_progress(phantom.APP_PROG_CONNECTING_TO_ELLIPSES, base_url)
-            resp = requests.get(  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
-                rest_endpoint, auth=self._auth, verify=verify
-            )
+            resp = requests.get(rest_endpoint, auth=self._auth, verify=verify, stream=True, timeout=(10, 60))
+            response_text = read_bounded_xml_response(resp)
         except Exception as e:
             return False, str(e)
 
         if resp.status_code == 200:
             return True, ""
 
-        return False, resp.text
+        return False, response_text[:4096]
 
     def _test_connectivity(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))

--- a/ciscoise_connector.py
+++ b/ciscoise_connector.py
@@ -29,8 +29,12 @@ from requests.auth import HTTPBasicAuth
 # THIS Connector imports
 from ciscoise_consts import *
 from ciscoise_utils import (
+    DEFAULT_MAX_TOTAL_RESULTS,
+    MAX_ERS_ACCUMULATED_BYTES,
+    MAX_ERS_RESOURCE_BYTES,
     build_ers_update,
     encode_ers_resource_id,
+    read_bounded_ers_response,
     read_bounded_xml_response,
     validate_next_page_href,
     validate_page_count,
@@ -148,16 +152,29 @@ class CiscoISEConnector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, CISCOISE_ERROR_REST_API, e), ret_data
         try:
             headers = {"Content-Type": "application/json", "ACCEPT": "application/json"}
-            resp = request_func(  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
-                url, json=data, verify=verify, headers=headers, auth=auth_method, params=params
+            resp = request_func(
+                url,
+                json=data,
+                verify=verify,
+                headers=headers,
+                auth=auth_method,
+                params=params,
+                stream=True,
+                timeout=(10, 60),
             )
 
         except Exception as e:
             self.debug_print(f"Exception occurred: {e}")
             return action_result.set_status(phantom.APP_ERROR, CISCOISE_ERROR_REST_API, e), ret_data
 
+        try:
+            response_text = read_bounded_ers_response(resp)
+        except Exception as e:
+            self.debug_print(f"Exception occurred: {e}")
+            return action_result.set_status(phantom.APP_ERROR, CISCOISE_ERROR_REST_API, e), ret_data
+
         if not (200 <= resp.status_code < 399):
-            error_message = resp.text
+            error_message = response_text[:4096]
             if resp.status_code == 401:
                 error_message = "The request has not been applied because it lacks valid authentication credentials for the target resource."
             elif resp.status_code == 404:
@@ -167,10 +184,14 @@ class CiscoISEConnector(BaseConnector):
                 ret_data,
             )
 
-        if not resp.text:
+        if not response_text:
             return (action_result.set_status(phantom.APP_SUCCESS, "Empty response and no information in the header"), None)
 
-        ret_data = json.loads(resp.text)
+        try:
+            ret_data = json.loads(response_text)
+        except Exception as e:
+            self.debug_print(f"Exception occurred: {e}")
+            return action_result.set_status(phantom.APP_ERROR, CISCOISE_ERROR_UNABLE_TO_PARSE_REPLY, e), None
 
         return phantom.APP_SUCCESS, ret_data
 
@@ -431,6 +452,14 @@ class CiscoISEConnector(BaseConnector):
         items_list = list()
         params = {}
         page_count = 0
+        accumulated_bytes = 0
+        seen_endpoints = {endpoint}
+        if limit is not None and limit > DEFAULT_MAX_TOTAL_RESULTS:
+            action_result.set_status(
+                phantom.APP_ERROR,
+                f"Cisco ISE result limit cannot exceed {DEFAULT_MAX_TOTAL_RESULTS}",
+            )
+            return None
         if limit:
             params["size"] = min(DEFAULT_MAX_RESULTS, limit)
         else:
@@ -442,16 +471,38 @@ class CiscoISEConnector(BaseConnector):
                 self.debug_print("Call to ERS API Failed")
                 return None
             page_count += 1
-            items_from_page = items.get("SearchResult", {}).get("resources", [])
+            if not isinstance(items, dict) or not isinstance(items.get("SearchResult"), dict):
+                action_result.set_status(phantom.APP_ERROR, "Cisco ISE returned an invalid paginated response")
+                return None
+            items_from_page = items["SearchResult"].get("resources", [])
+            if not isinstance(items_from_page, list) or len(items_from_page) > params["size"]:
+                action_result.set_status(phantom.APP_ERROR, "Cisco ISE returned too many resources in one page")
+                return None
 
-            items_list.extend(items_from_page)
+            remaining = (limit if limit is not None else DEFAULT_MAX_TOTAL_RESULTS) - len(items_list)
+            retained_items = items_from_page[:remaining]
+            for item in retained_items:
+                try:
+                    item_bytes = len(json.dumps(item, ensure_ascii=False).encode("utf-8"))
+                except (TypeError, ValueError):
+                    action_result.set_status(phantom.APP_ERROR, "Cisco ISE returned an invalid resource object")
+                    return None
+                if item_bytes > MAX_ERS_RESOURCE_BYTES:
+                    action_result.set_status(phantom.APP_ERROR, "Cisco ISE returned an oversized resource object")
+                    return None
+                accumulated_bytes += item_bytes
+                if accumulated_bytes > MAX_ERS_ACCUMULATED_BYTES:
+                    action_result.set_status(phantom.APP_ERROR, "Cisco ISE resources exceeded the cumulative size limit")
+                    return None
+            items_list.extend(retained_items)
             self.debug_print(f"Retrieved {len(items_from_page)} records from the endpoint {endpoint}")
 
             next_page_dict = items.get("SearchResult", {}).get("nextPage")
 
-            if limit and len(items_list) >= limit:
+            result_limit = limit if limit is not None else DEFAULT_MAX_TOTAL_RESULTS
+            if len(items_list) >= result_limit:
                 self.debug_print("Maximum limit reached")
-                return items_list[:limit]
+                return items_list[:result_limit]
             else:
                 if not next_page_dict:
                     self.debug_print("No more records left to retrieve")
@@ -470,6 +521,10 @@ class CiscoISEConnector(BaseConnector):
                     except ValueError as exc:
                         action_result.set_status(phantom.APP_ERROR, str(exc))
                         return None
+                    if endpoint in seen_endpoints:
+                        action_result.set_status(phantom.APP_ERROR, "Cisco ISE returned a repeated nextPage URL")
+                        return None
+                    seen_endpoints.add(endpoint)
                     self.debug_print("Next page available")
 
     def _list_resources(self, param):

--- a/ciscoise_connector.py
+++ b/ciscoise_connector.py
@@ -30,7 +30,7 @@ from requests.auth import HTTPBasicAuth
 from ciscoise_consts import *
 from ciscoise_utils import (
     build_ers_update,
-    encode_path_segment,
+    encode_ers_resource_id,
     read_bounded_xml_response,
     validate_next_page_href,
     validate_page_count,
@@ -301,7 +301,10 @@ class CiscoISEConnector(BaseConnector):
     def _get_endpoint(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        endpoint = ERS_ENDPOINT_REST + "/" + encode_path_segment(param["endpoint_id"])
+        try:
+            endpoint = ERS_ENDPOINT_REST + "/" + encode_ers_resource_id(param["endpoint_id"])
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
 
         ret_val, ret_data = self._call_ers_api(endpoint, action_result)
 
@@ -315,7 +318,10 @@ class CiscoISEConnector(BaseConnector):
     def _update_endpoint(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        endpoint = ERS_ENDPOINT_REST + "/" + encode_path_segment(param["endpoint_id"])
+        try:
+            endpoint = ERS_ENDPOINT_REST + "/" + encode_ers_resource_id(param["endpoint_id"])
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
         attribute = param.get("attribute", None)
         attribute_value = param.get("attribute_value", None)
         custom_attribute = param.get("custom_attribute", None)
@@ -521,7 +527,10 @@ class CiscoISEConnector(BaseConnector):
 
             return action_result.set_status(phantom.APP_SUCCESS)
 
-        endpoint = f"{ERS_RESOURCE_REST.format(resource=resource)}/{encode_path_segment(resource_id)}"
+        try:
+            endpoint = f"{ERS_RESOURCE_REST.format(resource=resource)}/{encode_ers_resource_id(resource_id)}"
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
 
         ret_val, resp = self._call_ers_api(endpoint, action_result)
         if phantom.is_fail(ret_val):
@@ -540,7 +549,10 @@ class CiscoISEConnector(BaseConnector):
         resource = MAP_RESOURCE[param["resource"]][0]
         resource_id = param["resource_id"]
 
-        endpoint = f"{ERS_RESOURCE_REST.format(resource=resource)}/{encode_path_segment(resource_id)}"
+        try:
+            endpoint = f"{ERS_RESOURCE_REST.format(resource=resource)}/{encode_ers_resource_id(resource_id)}"
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
 
         ret_val, resp = self._call_ers_api(endpoint, action_result, method="delete")
         if phantom.is_fail(ret_val):
@@ -574,7 +586,10 @@ class CiscoISEConnector(BaseConnector):
         key = param["key"]
         value = param["value"]
 
-        endpoint = f"{ERS_RESOURCE_REST.format(resource=resource)}/{encode_path_segment(resource_id)}"
+        try:
+            endpoint = f"{ERS_RESOURCE_REST.format(resource=resource)}/{encode_ers_resource_id(resource_id)}"
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
 
         ret_val, current_data = self._call_ers_api(endpoint, action_result)
         if phantom.is_fail(ret_val):
@@ -678,7 +693,10 @@ class CiscoISEConnector(BaseConnector):
     def _delete_policy(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        endpoint = f"{ERS_POLICIES}/{encode_path_segment(param['policy_name'])}"
+        try:
+            endpoint = f"{ERS_POLICIES}/{encode_ers_resource_id(param['policy_name'])}"
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
 
         ret_val, ret_data = self._call_ers_api(endpoint, action_result, method="delete")
 
@@ -764,7 +782,10 @@ class CiscoISEConnector(BaseConnector):
     def _get_anc_endpoint(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        endpoint = ERS_ENDPOINT_ANC + "/" + encode_path_segment(param["endpoint_id"])
+        try:
+            endpoint = ERS_ENDPOINT_ANC + "/" + encode_ers_resource_id(param["endpoint_id"])
+        except ValueError as exc:
+            return action_result.set_status(phantom.APP_ERROR, str(exc))
 
         ret_val, ret_data = self._call_ers_api(endpoint, action_result)
 

--- a/ciscoise_utils.py
+++ b/ciscoise_utils.py
@@ -20,6 +20,10 @@ from urllib.parse import quote, unquote, urljoin, urlsplit, urlunsplit
 
 
 DEFAULT_MAX_PAGES = 1000
+DEFAULT_MAX_TOTAL_RESULTS = 10_000
+MAX_ERS_ACCUMULATED_BYTES = 20 * 1024 * 1024
+MAX_ERS_RESOURCE_BYTES = 1024 * 1024
+MAX_ERS_RESPONSE_BYTES = 5 * 1024 * 1024
 MAX_XML_RESPONSE_BYTES = 20 * 1024 * 1024
 UNSAFE_XML_DECLARATION = re.compile(r"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
 
@@ -71,7 +75,8 @@ def validate_next_page_href(href: object, allowed_base_urls: list[str]) -> str:
     if not parsed.path.startswith("/ers/config/") or any(segment in {".", ".."} for segment in decoded_segments):
         raise ValueError("Cisco ISE nextPage URL is outside the ERS configuration API")
 
-    return urlunsplit(("", "", parsed.path, parsed.query, ""))
+    relative_target = urlunsplit(("", "", parsed.path, parsed.query, ""))
+    return f":9060{relative_target}"
 
 
 def validate_page_count(page_count: int, max_pages: int = DEFAULT_MAX_PAGES) -> None:
@@ -80,13 +85,13 @@ def validate_page_count(page_count: int, max_pages: int = DEFAULT_MAX_PAGES) -> 
         raise ValueError(f"Cisco ISE pagination exceeded the {max_pages}-page safety limit")
 
 
-def read_bounded_xml_response(response: object, max_bytes: int = MAX_XML_RESPONSE_BYTES) -> str:
-    """Read an HTTP response without accepting an unbounded XML document."""
+def read_bounded_response(response: object, max_bytes: int, response_kind: str) -> str:
+    """Read an HTTP response without accepting an unbounded body."""
     content_length = getattr(response, "headers", {}).get("Content-Length")
     if content_length:
         try:
             if int(content_length) > max_bytes:
-                raise ValueError(f"Cisco ISE XML response exceeds the {max_bytes}-byte limit")
+                raise ValueError(f"Cisco ISE {response_kind} response exceeds the {max_bytes}-byte limit")
         except ValueError as exc:
             if "exceeds" in str(exc):
                 raise
@@ -100,11 +105,21 @@ def read_bounded_xml_response(response: object, max_bytes: int = MAX_XML_RESPONS
             chunk = chunk.encode(getattr(response, "encoding", None) or "utf-8")
         total += len(chunk)
         if total > max_bytes:
-            raise ValueError(f"Cisco ISE XML response exceeds the {max_bytes}-byte limit")
+            raise ValueError(f"Cisco ISE {response_kind} response exceeds the {max_bytes}-byte limit")
         chunks.append(chunk)
 
     encoding = getattr(response, "encoding", None) or "utf-8"
     return b"".join(chunks).decode(encoding, errors="replace")
+
+
+def read_bounded_ers_response(response: object) -> str:
+    """Read a bounded ERS JSON response body."""
+    return read_bounded_response(response, MAX_ERS_RESPONSE_BYTES, "ERS")
+
+
+def read_bounded_xml_response(response: object) -> str:
+    """Read a bounded MnT XML response body."""
+    return read_bounded_response(response, MAX_XML_RESPONSE_BYTES, "MnT")
 
 
 def validate_xml_document(xml: str) -> None:

--- a/ciscoise_utils.py
+++ b/ciscoise_utils.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import re
+import uuid
 from copy import deepcopy
 from urllib.parse import quote, unquote, urljoin, urlsplit, urlunsplit
 
@@ -23,9 +24,17 @@ MAX_XML_RESPONSE_BYTES = 20 * 1024 * 1024
 UNSAFE_XML_DECLARATION = re.compile(r"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
 
 
-def encode_path_segment(value: object) -> str:
-    """Encode an action parameter as exactly one URL path segment."""
-    return quote(str(value), safe="")
+def encode_ers_resource_id(value: object) -> str:
+    """Validate and encode a Cisco ISE ERS UUID as one URL path segment."""
+    if not isinstance(value, str):
+        raise ValueError("Cisco ISE resource identifiers must be strings")
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError("Cisco ISE resource identifiers must be UUIDs") from exc
+    if str(parsed) != value.casefold():
+        raise ValueError("Cisco ISE resource identifiers must use canonical UUID syntax")
+    return quote(value, safe="")
 
 
 def validate_next_page_href(href: object, allowed_base_urls: list[str]) -> str:

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 - Require canonical UUIDs for Cisco ISE resource identifiers used in ERS paths.
+- Bound ERS response bodies, resource pages, retained objects, pagination, and request duration.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,5 @@
 **Unreleased**
 
-- Require canonical UUIDs for Cisco ISE resource identifiers used in ERS paths.
-- Bound ERS response bodies, resource pages, retained objects, pagination, and request duration.
+* Require canonical UUIDs for Cisco ISE resource identifiers used in ERS paths.
+* Bound ERS response bodies, resource pages, retained objects, pagination, and request duration.
+* Bound MnT response bodies and request duration on both success and error paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Require canonical UUIDs for Cisco ISE resource identifiers used in ERS paths.


### PR DESCRIPTION
## Summary

AI-authored follow-up for [PAPP-37969](https://splunk.atlassian.net/browse/PAPP-37969), under [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228).

This change:

* requires canonical UUID syntax for ERS resource identifiers before path construction;
* bounds ERS response bytes, page sizes, retained object sizes, total retained data, request duration, and continuation behavior;
* preserves port 9060 when following validated ERS continuation URLs; and
* applies the existing MnT body limit to error responses and connectivity checks, with bounded request duration.

The identifier validation commit is intentionally marked breaking because previously accepted non-UUID values will now be rejected. The other two fixes remain patch-level changes.

## Tracking

* [PSAAS-30645](https://splunk.atlassian.net/browse/PSAAS-30645)
* [PSAAS-31766](https://splunk.atlassian.net/browse/PSAAS-31766)
* [PSAAS-32218](https://splunk.atlassian.net/browse/PSAAS-32218)
* [PSAAS-30802](https://splunk.atlassian.net/browse/PSAAS-30802) is undergoing corrected-scope validation against the already-merged secure-default change and does not add a migration mechanism here.

## Quality gate

* Full local pre-commit: passed
* Hosted pre-commit and compile: pending
* Connector unit tests: unavailable for this BaseConnector app

Please preserve the individual commits when merging; semantic release relies on them.

_Description updated by Codex._

Merge strategy: merge commit only; do not squash.
